### PR TITLE
define RewriteBase as / by default

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,6 +15,7 @@ RewriteEngine on
 # Set the RewriteBase to:
 #
 # RewriteBase /mysite
+RewriteBase /
 
 # block text files in the content folder from being accessed directly
 RewriteRule ^content/(.*)\.(txt|md|mdown)$ error [R=301,L]


### PR DESCRIPTION
To prevent errors on dynamic virtual hosts (and maybe other situations) rewrite base is defined as /
